### PR TITLE
Log messages with placeholders

### DIFF
--- a/airbrake.module
+++ b/airbrake.module
@@ -44,7 +44,7 @@ function airbrake_watchdog($log) {
       $notice->load(array(
           'errorClass'   => 'Drupal Error',
           'backtrace'    => $backtrace,
-          'errorMessage' => $log['message'],
+          'errorMessage' => strip_tags(format_string($log['message'], $log['variables'])),
       ));
       
       $headers = array(


### PR DESCRIPTION
We're using errbit error catcher, and when the application logs messages with placeholders they are displayed as "%type​: !me​ssage​ in %​funct​ion (​line ​%line​ of %​file)​.".
This minimal fix should resolve this issue.
